### PR TITLE
Improve iOS mobile control buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,13 @@
       color:white; font-size:5vw; font-weight:800;
       display:flex; align-items:center; justify-content:center;
       box-shadow:0 1vh 2vh rgba(0,0,0,0.35);
-      -webkit-tap-highlight-color:transparent; user-select:none;
+      -webkit-tap-highlight-color:transparent;
+      user-select:none;
+      -webkit-user-select:none;
+      -ms-user-select:none;
+      -moz-user-select:none;
+      -webkit-touch-callout:none;
+      touch-action:manipulation;
       backdrop-filter:blur(0.4vw);
     }
     .btn:active { background:rgba(0,0,0,0.85); }
@@ -56,6 +62,13 @@
     @media (min-width:601px) {
       #controls { flex-direction:row; }
       .btn { width:8vh; height:8vh; font-size:3vh; }
+    }
+
+    /* iOS:大きめボタン */
+    body.ios .btn {
+      width:45vw !important;
+      height:45vw !important;
+      font-size:15vw !important;
     }
   </style>
 </head>
@@ -80,6 +93,11 @@
   </div>
 
 <script>
+/********************** iOS調整 **********************/
+if(/iPad|iPhone|iPod/.test(navigator.userAgent)){
+  document.body.classList.add('ios');
+}
+
 /********************** 入力管理（PC+モバイル） **********************/
 let keys = {};
 // キーボード


### PR DESCRIPTION
## Summary
- Expand mobile control buttons to 300% size on iOS
- Prevent iOS text selection and touch callouts for controls
- Add iOS detection script to enable enhanced button layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c170dde7b08330992bfb50d72c3154